### PR TITLE
Dockerize Connect-4 Project and Set Up Kubernetes Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+
+COPY . /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connect4-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: connect4
+  template:
+    metadata:
+      labels:
+        app: connect4
+    spec:
+      containers:
+      - name: connect4-app
+        image: moonlovesmoon/connect4-app:latest # You have to use your dockerhub username here
+        ports:
+        - containerPort: 80
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: connect4-service
+spec:
+  type: NodePort  
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30000  
+  selector:
+    app: connect4


### PR DESCRIPTION
This pull request introduces Dockerization of the Connect-4 project and sets up a Kubernetes deployment to streamline the deployment process. As I’m new to Kubernetes, this project has been a valuable learning experience for me.

Changes Made:

Dockerfile:

**Added a Dockerfile to build a Docker image using nginx to serve the static files of the Connect-4 application.**
The image is built from the official nginx:alpine base image for lightweight performance.
Kubernetes Deployment:

Created a deployment.yaml file containing:
**A Kubernetes Deployment that manages two replicas of the application for high availability.**
A Service of type LoadBalancer to expose the application externally.
Purpose:

To enable easy deployment and scalability of the Connect-4 application using Docker and Kubernetes.
To facilitate collaboration and deployment in a cloud environment.
Testing Instructions:

Build the Docker image using:
bash
Copy code
docker build -t connect4-app .
Test the application locally:
bash
Copy code
docker run -d -p 8080:80 connect4-app
Open localhost:8080 in your browser to view the application.
Deploy to Kubernetes using:
bash
Copy code
kubectl apply -f deployment.yaml
Access the application through the external IP provided by the Kubernetes service.
Additional Notes:

I’m still learning Kubernetes, so any feedback or suggestions would be greatly appreciated!
Ensure you have Docker and Kubernetes set up before testing.
Replace <your-dockerhub-username> in the YAML with your actual Docker Hub username before deployment.
